### PR TITLE
feat(parser): include tag in collection start

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,10 +44,10 @@ pub enum Event {
     /// Value, style, anchor_id, tag
     Scalar(String, TScalarStyle, usize, Option<TokenType>),
     /// Anchor ID
-    SequenceStart(usize),
+    SequenceStart(usize, Option<TokenType>),
     SequenceEnd,
     /// Anchor ID
-    MappingStart(usize),
+    MappingStart(usize, Option<TokenType>),
     MappingEnd,
 }
 
@@ -233,11 +233,11 @@ impl<T: Iterator<Item = char>> Parser<T> {
                 recv.on_event(first_ev, mark);
                 Ok(())
             }
-            Event::SequenceStart(_) => {
+            Event::SequenceStart(..) => {
                 recv.on_event(first_ev, mark);
                 self.load_sequence(recv)
             }
-            Event::MappingStart(_) => {
+            Event::MappingStart(..) => {
                 recv.on_event(first_ev, mark);
                 self.load_mapping(recv)
             }
@@ -497,7 +497,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
         match *self.peek_token()? {
             Token(mark, TokenType::BlockEntry) if indentless_sequence => {
                 self.state = State::IndentlessSequenceEntry;
-                Ok((Event::SequenceStart(anchor_id), mark))
+                Ok((Event::SequenceStart(anchor_id, tag), mark))
             }
             Token(_, TokenType::Scalar(..)) => {
                 self.pop_state();
@@ -509,19 +509,19 @@ impl<T: Iterator<Item = char>> Parser<T> {
             }
             Token(mark, TokenType::FlowSequenceStart) => {
                 self.state = State::FlowSequenceFirstEntry;
-                Ok((Event::SequenceStart(anchor_id), mark))
+                Ok((Event::SequenceStart(anchor_id, tag), mark))
             }
             Token(mark, TokenType::FlowMappingStart) => {
                 self.state = State::FlowMappingFirstKey;
-                Ok((Event::MappingStart(anchor_id), mark))
+                Ok((Event::MappingStart(anchor_id, tag), mark))
             }
             Token(mark, TokenType::BlockSequenceStart) if block => {
                 self.state = State::BlockSequenceFirstEntry;
-                Ok((Event::SequenceStart(anchor_id), mark))
+                Ok((Event::SequenceStart(anchor_id, tag), mark))
             }
             Token(mark, TokenType::BlockMappingStart) if block => {
                 self.state = State::BlockMappingFirstKey;
-                Ok((Event::MappingStart(anchor_id), mark))
+                Ok((Event::MappingStart(anchor_id, tag), mark))
             }
             // ex 7.2, an empty scalar can follow a secondary tag
             Token(mark, _) if tag.is_some() || anchor_id > 0 => {
@@ -718,7 +718,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
             Token(mark, TokenType::Key) => {
                 self.state = State::FlowSequenceEntryMappingKey;
                 self.skip();
-                Ok((Event::MappingStart(0), mark))
+                Ok((Event::MappingStart(0, None), mark))
             }
             _ => {
                 self.push_state(State::FlowSequenceEntry);
@@ -831,7 +831,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
 
 #[cfg(test)]
 mod test {
-    use super::{Event, Parser};
+    use super::{Event, Parser, TokenType};
 
     #[test]
     fn test_peek_eq_parse() {
@@ -854,5 +854,68 @@ a5: *x
             assert_eq!(event, event_peek);
             event.0 != Event::StreamEnd
         } {}
+    }
+
+    #[test]
+    fn test_tagged_block_mapping() {
+        let s = "
+!customtag
+key: value
+";
+        let mut p = Parser::new(s.chars());
+        assert_eq!(p.next().unwrap().0, Event::StreamStart);
+        assert_eq!(p.next().unwrap().0, Event::DocumentStart);
+        assert_eq!(
+            p.next().unwrap().0,
+            Event::MappingStart(
+                0,
+                Some(TokenType::Tag("!".to_string(), "customtag".to_string()))
+            )
+        );
+    }
+    #[test]
+    fn test_tagged_flow_mapping() {
+        let s = "!customtag {\"key\": \"value\"}";
+        let mut p = Parser::new(s.chars());
+        assert_eq!(p.next().unwrap().0, Event::StreamStart);
+        assert_eq!(p.next().unwrap().0, Event::DocumentStart);
+        assert_eq!(
+            p.next().unwrap().0,
+            Event::MappingStart(
+                0,
+                Some(TokenType::Tag("!".to_string(), "customtag".to_string()))
+            )
+        );
+    }
+    #[test]
+    fn test_tagged_block_sequence() {
+        let s = "
+!customtag
+- item
+";
+        let mut p = Parser::new(s.chars());
+        assert_eq!(p.next().unwrap().0, Event::StreamStart);
+        assert_eq!(p.next().unwrap().0, Event::DocumentStart);
+        assert_eq!(
+            p.next().unwrap().0,
+            Event::SequenceStart(
+                0,
+                Some(TokenType::Tag("!".to_string(), "customtag".to_string()))
+            )
+        );
+    }
+    #[test]
+    fn test_tagged_flow_sequence() {
+        let s = "!customtag [item]";
+        let mut p = Parser::new(s.chars());
+        assert_eq!(p.next().unwrap().0, Event::StreamStart);
+        assert_eq!(p.next().unwrap().0, Event::DocumentStart);
+        assert_eq!(
+            p.next().unwrap().0,
+            Event::SequenceStart(
+                0,
+                Some(TokenType::Tag("!".to_string(), "customtag".to_string()))
+            )
+        );
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -90,14 +90,14 @@ impl MarkedEventReceiver for YamlLoader {
                     _ => unreachable!(),
                 }
             }
-            Event::SequenceStart(aid) => {
+            Event::SequenceStart(aid, _) => {
                 self.doc_stack.push((Yaml::Array(Vec::new()), aid));
             }
             Event::SequenceEnd => {
                 let node = self.doc_stack.pop().unwrap();
                 self.insert_new_node(node);
             }
-            Event::MappingStart(aid) => {
+            Event::MappingStart(aid, _) => {
                 self.doc_stack.push((Yaml::Hash(Hash::new()), aid));
                 self.key_stack.push(Yaml::BadValue);
             }


### PR DESCRIPTION
Parser will now emit events for collection starts that contain the applicable tag if present.